### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/src/scripts/build.js
+++ b/src/scripts/build.js
@@ -94,7 +94,7 @@ ${modsList.map(mod => {
 				links.push(" ");
 			}
 			if (mod.links.github !== undefined) {
-				links.push(html`<a href=${mod.links.github}>Github</a>`);
+				links.push(html`<a href=${mod.links.github}>GitHub</a>`);
 				links.push(" ");
 			}
 			if (mod.links.website !== undefined) {


### PR DESCRIPTION
Minor tweak, but mods' GitHub links had been displaying as `Github` instead of `GitHub`. Very trivial, but bothered me for some reason xD