### PR TITLE
Mark mods as abandoned / outdated

### DIFF
--- a/src/mods/auto-backup.toml
+++ b/src/mods/auto-backup.toml
@@ -3,3 +3,4 @@ links.curseforge = 'https://www.curseforge.com/minecraft/mc-mods/auto-backup'
 categories = [
 	'server-management/backups',
 ]
+metadata.outdated = true

--- a/src/mods/cheater-deleter.toml
+++ b/src/mods/cheater-deleter.toml
@@ -3,3 +3,4 @@ links.github = 'https://github.com/CoolMineman/CheaterDeleter'
 categories = [
 	'server-management/anticheat-anti-x-ray',
 ]
+metadata.outdated = true

--- a/src/mods/chest-games.toml
+++ b/src/mods/chest-games.toml
@@ -3,3 +3,4 @@ links.modrinth = 'https://modrinth.com/mod/chest-games'
 categories = [
 	'gamemodes-minigames',
 ]
+metadata.outdated = true

--- a/src/mods/cyansethome.toml
+++ b/src/mods/cyansethome.toml
@@ -4,4 +4,4 @@ categories = [
 	'commands/teleportation-homes',
 ]
 metadata.outdated = true
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/cyansethome.toml
+++ b/src/mods/cyansethome.toml
@@ -3,3 +3,5 @@ links.modrinth = 'https://modrinth.com/mod/cyansethome'
 categories = [
 	'commands/teleportation-homes',
 ]
+metadata.outdated = true
+notes = 'Abandoned'

--- a/src/mods/defibrillator.toml
+++ b/src/mods/defibrillator.toml
@@ -3,3 +3,4 @@ links.modrinth = 'https://modrinth.com/mod/defibrillator'
 categories = [
 	'server-management',
 ]
+metadata.outdated = true

--- a/src/mods/fabric-console.toml
+++ b/src/mods/fabric-console.toml
@@ -4,4 +4,4 @@ categories = [
 	'server-management/console-logs',
 ]
 metadata.outdated = true
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/fabric-console.toml
+++ b/src/mods/fabric-console.toml
@@ -3,3 +3,5 @@ links.curseforge = 'https://www.curseforge.com/minecraft/mc-mods/fabric-console'
 categories = [
 	'server-management/console-logs',
 ]
+metadata.outdated = true
+notes = 'Abandoned'

--- a/src/mods/fabric-restart.toml
+++ b/src/mods/fabric-restart.toml
@@ -3,3 +3,4 @@ links.curseforge = 'https://www.curseforge.com/minecraft/mc-mods/fabric-restart'
 categories = [
 	'server-management',
 ]
+notes = 'Abandoned'

--- a/src/mods/fabric-restart.toml
+++ b/src/mods/fabric-restart.toml
@@ -3,4 +3,4 @@ links.curseforge = 'https://www.curseforge.com/minecraft/mc-mods/fabric-restart'
 categories = [
 	'server-management',
 ]
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/fabrilous-updater.toml
+++ b/src/mods/fabrilous-updater.toml
@@ -3,3 +3,5 @@ links.curseforge = 'https://www.curseforge.com/minecraft/mc-mods/fabrilous-updat
 categories = [
 	'server-management',
 ]
+metadata.outdated = true
+notes = 'Abandoned'

--- a/src/mods/fabrilous-updater.toml
+++ b/src/mods/fabrilous-updater.toml
@@ -4,4 +4,4 @@ categories = [
 	'server-management',
 ]
 metadata.outdated = true
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/gamerulify.toml
+++ b/src/mods/gamerulify.toml
@@ -3,3 +3,5 @@ links.modrinth = 'https://modrinth.com/mod/gamerulify'
 categories = [
 	'server-management',
 ]
+metadata.outdated = true
+notes = 'Abandoned'

--- a/src/mods/gamerulify.toml
+++ b/src/mods/gamerulify.toml
@@ -4,4 +4,4 @@ categories = [
 	'server-management',
 ]
 metadata.outdated = true
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/jsonchat.toml
+++ b/src/mods/jsonchat.toml
@@ -3,3 +3,5 @@ links.modrinth = 'https://modrinth.com/mod/jsonchat'
 categories = [
 	'chat',
 ]
+metadata.outdated = true
+notes = 'Abandoned'

--- a/src/mods/jsonchat.toml
+++ b/src/mods/jsonchat.toml
@@ -4,4 +4,4 @@ categories = [
 	'chat',
 ]
 metadata.outdated = true
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/mc-198678-fix.toml
+++ b/src/mods/mc-198678-fix.toml
@@ -3,4 +3,5 @@ links.github = 'https://github.com/Fallen-Breath/mc-198678-fix'
 categories = [
 	'bugfixes',
 ]
+metadata.outdated = true
 notes = 'fixed by 1.16.3'

--- a/src/mods/minecraft-manhunt.toml
+++ b/src/mods/minecraft-manhunt.toml
@@ -3,3 +3,4 @@ links.modrinth = 'https://modrinth.com/mod/minecraft-manhunt'
 categories = [
 	'gamemodes-minigames',
 ]
+metadata.outdated = true

--- a/src/mods/simplehomes.toml
+++ b/src/mods/simplehomes.toml
@@ -4,4 +4,4 @@ categories = [
 	'commands/teleportation-homes',
 ]
 metadata.outdated = true
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/simplehomes.toml
+++ b/src/mods/simplehomes.toml
@@ -3,3 +3,5 @@ links.modrinth = 'https://modrinth.com/mod/simplehomes'
 categories = [
 	'commands/teleportation-homes',
 ]
+metadata.outdated = true
+notes = 'Abandoned'

--- a/src/mods/spawn-protection-tweaks.toml
+++ b/src/mods/spawn-protection-tweaks.toml
@@ -4,4 +4,4 @@ categories = [
 	'claims-world-protection',
 ]
 metadata.outdated = true
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/spawn-protection-tweaks.toml
+++ b/src/mods/spawn-protection-tweaks.toml
@@ -3,3 +3,5 @@ links.modrinth = 'https://modrinth.com/mod/spawn-protection-tweaks'
 categories = [
 	'claims-world-protection',
 ]
+metadata.outdated = true
+notes = 'Abandoned'

--- a/src/mods/thirdlife-soulsplit.toml
+++ b/src/mods/thirdlife-soulsplit.toml
@@ -3,3 +3,4 @@ links.curseforge = 'https://www.curseforge.com/minecraft/mc-mods/thirdlife-souls
 categories = [
 	'gamemodes-minigames',
 ]
+metadata.outdated = true

--- a/src/mods/whos-pet-is-this.toml
+++ b/src/mods/whos-pet-is-this.toml
@@ -4,4 +4,4 @@ categories = [
 	'commands',
 ]
 metadata.outdated = true
-notes = 'Abandoned'
+metadata.abandoned = true

--- a/src/mods/whos-pet-is-this.toml
+++ b/src/mods/whos-pet-is-this.toml
@@ -3,3 +3,5 @@ links.curseforge = 'https://www.curseforge.com/minecraft/mc-mods/whos-pet-is-thi
 categories = [
 	'commands',
 ]
+metadata.outdated = true
+notes = 'Abandoned'


### PR DESCRIPTION
I have not gone through all mods and where in doubt I didn't mark them as outdated / abandoned.
I only marked mods as outdated which:
a) depend on other mods which are not available for newer versions
b) have open issues / comments about ports to newer versions / them not working in newer versions

I additionally marked mods as abandoned which:
a) are marked as archived/deprecated/abandoned on their GitHub
b) are marked as archived/deprecated/abandoned on their Modrinth / CurseForge