### PR TITLE
AntiShulkerDupe - outdated

### DIFF
--- a/src/mods/antishulkerdupe.toml
+++ b/src/mods/antishulkerdupe.toml
@@ -4,4 +4,4 @@ categories = [
 	'bugfixes',
 ]
 metadata.outdated = true
-notes = 'fixed in 1.19.1'
+notes = 'fixed by 1.19.1'

--- a/src/mods/antishulkerdupe.toml
+++ b/src/mods/antishulkerdupe.toml
@@ -3,3 +3,5 @@ links.modrinth = 'https://modrinth.com/mod/antishulkerdupe'
 categories = [
 	'bugfixes',
 ]
+metadata.outdated = true
+notes = 'fixed in 1.19.1'


### PR DESCRIPTION
The bug was fixed in 1.19.1. The main repo has this on the README: https://github.com/PotatoPresident/AntiShulkerDupe