### PR TITLE
Rename mcdiscordchat to discordmcchat

### DIFF
--- a/src/mods/discordmcchat.toml
+++ b/src/mods/discordmcchat.toml
@@ -1,0 +1,5 @@
+name = 'Discord-MC-Chat'
+links.modrinth = 'https://modrinth.com/mod/discord-mc-chat'
+categories = [
+	'chat-linking/discord',
+]

--- a/src/mods/mcdiscordchat.toml
+++ b/src/mods/mcdiscordchat.toml
@@ -1,5 +1,0 @@
-name = 'MCDiscordChat'
-links.modrinth = 'https://modrinth.com/mod/mcdiscordchat'
-categories = [
-	'chat-linking/discord',
-]


### PR DESCRIPTION
MCDiscordChat has renamed to Discord-MC-Chat which means the link is invalid, this PR fixes that.